### PR TITLE
fix: change ssh keys to remove all keys before adding ansible managed

### DIFF
--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -51,10 +51,6 @@
         public_keys: "{{ public_keys_prompt.user_input }}"
       when: public_keys is not defined
 
-    - name: Parse public keys
-      set_fact:
-        public_keys_array: "{{ public_keys.split(',') }}"
-
     - name: Set timezone to UTC
       timezone:
         name: UTC

--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -156,6 +156,7 @@
         user: root  
         key: "{{ item }}"
         state: present
+        exclusive: true
       loop: "{{ public_keys_array }}"
 
     - name: Reboot the target node


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Ensures only specified SSH keys are present in `authorized_keys`.

- Adds the `exclusive: true` parameter to the `authorized_key` module.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server-install.yml</strong><dd><code>Ensure exclusive SSH key management in playbook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/server-install.yml

<li>Added <code>exclusive: true</code> to the <code>authorized_key</code> module.<br> <li> Ensures only specified keys are present in <code>authorized_keys</code>.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/4/files#diff-4e91b59e98037adc8ba24f697e5b0057aaf84746f7bc1cd3972965b8c3a394c0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>