### PR TITLE
fix: added key var file and split orod and nonprodd hosts

### DIFF
--- a/group_vars/nonprod.yml
+++ b/group_vars/nonprod.yml
@@ -1,0 +1,4 @@
+keys: |
+  public-key1
+  public-key2
+  

--- a/group_vars/prod.yml
+++ b/group_vars/prod.yml
@@ -1,0 +1,4 @@
+keys: |
+  public-key1
+  public-key2
+  

--- a/inventory.ini
+++ b/inventory.ini
@@ -1,8 +1,8 @@
 [prod]
-127.0.0.1
+hostname1 127.0.0.1
 
 [nonprod]
-127.0.0.1
+hostname2 127.0.0.1
 
 [all:vars]
 ansible_ssh_private_key_file=../keys/ansible

--- a/inventory.ini
+++ b/inventory.ini
@@ -1,7 +1,10 @@
-[target_nodes]
+[prod]
 127.0.0.1
 
-[target_nodes:vars]
+[nonprod]
+127.0.0.1
+
+[all:vars]
 ansible_ssh_private_key_file=../keys/ansible
 ansible_ssh_user=root
 ansible_python_interpreter=/usr/bin/python3

--- a/keys.yml
+++ b/keys.yml
@@ -1,7 +1,0 @@
-keys:
-  prod: |
-    public-key1
-    public-key2
-  nonprod: |
-    public-key3
-    public-key4

--- a/keys.yml
+++ b/keys.yml
@@ -1,0 +1,7 @@
+keys:
+  prod: |
+    public-key1
+    public-key2
+  nonprod: |
+    public-key3
+    public-key4

--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -1,6 +1,8 @@
 ---
 - name: Setup Libvirt on the target node
-  hosts: target_nodes
+  hosts: all
+  vars_files:
+    - keys.yml
   become: yes
   tasks:
     - name: Set hostname if inventory_hostname is valid
@@ -12,11 +14,6 @@
       set_fact:
         tailscale_auth_key: "{{ lookup('env', 'TAILSCALE_AUTH_KEY') }}"
       when: lookup('env', 'TAILSCALE_AUTH_KEY') | length > 0
-
-    - name: Set public_keys if environment variable exists
-      set_fact:
-        public_keys: "{{ lookup('env', 'PUBLIC_KEYS') }}"
-      when: lookup('env', 'PUBLIC_KEYS') | length > 0
 
     - name: Prompt for hostname if not set
       pause:
@@ -39,21 +36,6 @@
       set_fact:
         tailscale_auth_key: "{{ tailscale_auth_key_prompt.user_input }}"
       when: tailscale_auth_key is not defined
-
-    - name: Prompt for public_keys if not set
-      pause:
-        prompt: "Enter the public keys (comma-separated)"
-      register: public_keys_prompt
-      when: public_keys is not defined
-
-    - name: Save public_keys if prompted
-      set_fact:
-        public_keys: "{{ public_keys_prompt.user_input }}"
-      when: public_keys is not defined
-
-    - name: Parse public keys
-      set_fact:
-        public_keys_array: "{{ public_keys.split(',') }}"
 
     - name: Set timezone to UTC
       timezone:
@@ -154,9 +136,9 @@
     - name: Add public key to authorized_keys
       authorized_key:
         user: root  
-        key: "{{ item }}"
+        key: "{{ keys[inventory_hostname] }}"
         state: present
-      loop: "{{ public_keys_array }}"
+        exclusive: true
 
     - name: Reboot the target node
       command: reboot

--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -131,6 +131,16 @@
         group: root
         mode: 0644
 
+    - name: Remove all users except root
+      user:
+        name: "{{ item }}"
+        state: absent
+        remove: yes
+      loop:
+        - glueops
+        - admin
+        - debian
+    
     - name: Add public key to authorized_keys
       authorized_key:
         user: root  

--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -1,8 +1,6 @@
 ---
 - name: Setup Libvirt on the target node
   hosts: all
-  vars_files:
-    - keys.yml
   become: yes
   tasks:
     - name: Set hostname if inventory_hostname is valid
@@ -136,7 +134,7 @@
     - name: Add public key to authorized_keys
       authorized_key:
         user: root  
-        key: "{{ keys[inventory_hostname] }}"
+        key: "{{ keys }}"
         state: present
         exclusive: true
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Split inventory into `prod` and `nonprod` groups.

- Introduced `keys.yml` for managing environment-specific SSH keys.

- Updated playbook to use `keys.yml` and removed manual public key prompts.

- Enhanced SSH key management with exclusive key addition.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inventory.ini</strong><dd><code>Refactored inventory for environment separation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inventory.ini

<li>Split <code>target_nodes</code> into <code>prod</code> and <code>nonprod</code> groups.<br> <li> Added <code>[all:vars]</code> for shared variables.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/5/files#diff-84b3d93a1acb6e9c090c7fc6a55a36f00072287d5e8bee891d27ef4648ed141b">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>keys.yml</strong><dd><code>Introduced `keys.yml` for SSH key management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

keys.yml

<li>Added a new file to manage SSH keys.<br> <li> Defined keys for <code>prod</code> and <code>nonprod</code> environments.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/5/files#diff-ca6d7dcad15816361652771d375d9f618ceafcb1e7c90220ed3566bf3f564477">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server-install.yml</strong><dd><code>Updated playbook for automated SSH key management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/server-install.yml

<li>Updated playbook to use <code>keys.yml</code> for SSH keys.<br> <li> Removed manual prompts for public keys.<br> <li> Enhanced SSH key addition to be exclusive.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/5/files#diff-4e91b59e98037adc8ba24f697e5b0057aaf84746f7bc1cd3972965b8c3a394c0">+5/-23</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>