### PR TITLE
fix: remove hostname prompt

### DIFF
--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -13,17 +13,6 @@
         tailscale_auth_key: "{{ lookup('env', 'TAILSCALE_AUTH_KEY') }}"
       when: lookup('env', 'TAILSCALE_AUTH_KEY') | length > 0
 
-    - name: Prompt for hostname if not set
-      pause:
-        prompt: "Enter the new hostname"
-      register: hostname_prompt
-      when: hostname is not defined
-
-    - name: Save hostname if prompted
-      set_fact:
-        hostname: "{{ hostname_prompt.user_input }}"
-      when: hostname is not defined
-
     - name: Prompt for tailscale_auth_key if not set
       pause:
         prompt: "Enter the tailscale auth key"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed the hostname prompt from the server installation playbook.

- Simplified hostname setting logic in Ansible tasks.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server-install.yml</strong><dd><code>Removed hostname prompt and simplified logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/server-install.yml

<li>Removed tasks prompting for hostname input.<br> <li> Simplified logic to set hostname directly from inventory.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/7/files#diff-4e91b59e98037adc8ba24f697e5b0057aaf84746f7bc1cd3972965b8c3a394c0">+0/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>