### PR TITLE
fix: inventory syntax

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -1,8 +1,8 @@
 [prod]
-hostname1 127.0.0.1
+hostname1 ansible_host=127.0.0.1
 
 [nonprod]
-hostname2 127.0.0.1
+hostname2 ansible_host=127.0.0.1
 
 [all:vars]
 ansible_ssh_private_key_file=../keys/ansible


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected syntax for defining host variables in `inventory.ini`.

- Replaced direct IP assignments with `ansible_host` syntax.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inventory.ini</strong><dd><code>Corrected host variable syntax in inventory file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inventory.ini

<li>Updated host definitions to use <code>ansible_host</code> syntax.<br> <li> Replaced direct IP assignments with proper Ansible variable.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/8/files#diff-84b3d93a1acb6e9c090c7fc6a55a36f00072287d5e8bee891d27ef4648ed141b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>