### PR TITLE
fix: install curl and tmux before tailscale

### DIFF
--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -62,12 +62,6 @@
         group: root
         mode: 0644
 
-    - name: Install tailscale
-      shell: curl -fsSL https://tailscale.com/install.sh | sh
-
-    - name: Start tailscale
-      command: tailscale up --authkey {{ tailscale_auth_key }} --ssh
- 
     - name: Install libvirt, libvirt dependencies, and other packages
       apt:
         name: 
@@ -82,8 +76,16 @@
           - xmlstarlet
           - jq
           - htop
+          - curl
+          - tmux
         state: present
         update_cache: yes
+    
+    - name: Install tailscale
+      shell: curl -fsSL https://tailscale.com/install.sh | sh
+        
+    - name: Start tailscale
+      command: tailscale up --authkey {{ tailscale_auth_key }} --ssh
     
     - name: Remove systemd-resolved
       apt:


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Reordered installation steps for `curl` and `tmux` before Tailscale.

- Ensured `curl` and `tmux` are explicitly installed as dependencies.

- Improved script reliability by addressing potential missing dependencies.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server-install.yml</strong><dd><code>Reorder and enhance Tailscale installation steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/server-install.yml

<li>Reordered Tailscale installation steps for dependency resolution.<br> <li> Added <code>curl</code> and <code>tmux</code> to the package installation list.<br> <li> Improved script reliability by ensuring prerequisites are installed.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/10/files#diff-4e91b59e98037adc8ba24f697e5b0057aaf84746f7bc1cd3972965b8c3a394c0">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>