### PR TITLE
fix: remove when false that prevented libvirt netwokr task from running

### DIFF
--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -112,7 +112,6 @@
         virsh net-start default
         virsh net-autostart default
       changed_when: false
-      when: false
 
     - name: Modify sshd_config
       template:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed incorrect `when: false` condition blocking libvirt network task.

- Ensured the default libvirt network starts and auto-starts correctly.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server-install.yml</strong><dd><code>Fix libvirt network task execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/server-install.yml

<li>Removed <code>when: false</code> condition from the libvirt network task.<br> <li> Ensured the task to start and auto-start the default libvirt network <br>is executed.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/11/files#diff-4e91b59e98037adc8ba24f697e5b0057aaf84746f7bc1cd3972965b8c3a394c0">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>