### PR TITLE
fix: remove reboot

### DIFF
--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -137,9 +137,3 @@
         key: "{{ keys }}"
         state: present
         exclusive: true
-
-    - name: Reboot the target node
-      command: reboot
-      async: 1
-      poll: 0
-      ignore_errors: yes


### PR DESCRIPTION
### **User description**
Remove reboot so the config can be ran on servers multiple times to push ssh keys.


___

### **PR Type**
Bug fix


___

### **Description**
- Removed reboot command to allow multiple configuration runs.

- Ensures SSH keys can be pushed repeatedly without interruption.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server-install.yml</strong><dd><code>Removed reboot command from server installation playbook</code>&nbsp; </dd></summary>
<hr>

playbooks/server-install.yml

<li>Removed the reboot command from the playbook.<br> <li> Ensures the configuration can run multiple times without rebooting.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/12/files#diff-4e91b59e98037adc8ba24f697e5b0057aaf84746f7bc1cd3972965b8c3a394c0">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>