### PR TITLE
fix: set tailscale tasks to only run if a auth key is provided

### DIFF
--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -13,17 +13,6 @@
         tailscale_auth_key: "{{ lookup('env', 'TAILSCALE_AUTH_KEY') }}"
       when: lookup('env', 'TAILSCALE_AUTH_KEY') | length > 0
 
-    - name: Prompt for tailscale_auth_key if not set
-      pause:
-        prompt: "Enter the tailscale auth key"
-      register: tailscale_auth_key_prompt
-      when: tailscale_auth_key is not defined
-
-    - name: Save tailscale_auth_key if prompted
-      set_fact:
-        tailscale_auth_key: "{{ tailscale_auth_key_prompt.user_input }}"
-      when: tailscale_auth_key is not defined
-
     - name: Set timezone to UTC
       timezone:
         name: UTC
@@ -83,9 +72,11 @@
     
     - name: Install tailscale
       shell: curl -fsSL https://tailscale.com/install.sh | sh
+      when: tailscale_auth_key is defined
         
     - name: Start tailscale
       command: tailscale up --authkey {{ tailscale_auth_key }} --ssh
+      when: tailscale_auth_key is defined
     
     - name: Remove systemd-resolved
       apt:


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed interactive prompt for `tailscale_auth_key` to streamline automation.

- Added conditional checks to ensure Tailscale tasks only run if `tailscale_auth_key` is defined.

- Improved task execution logic for better reliability and clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server-install.yml</strong><dd><code>Refactor Tailscale tasks to require auth key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/server-install.yml

<li>Removed interactive prompt for <code>tailscale_auth_key</code>.<br> <li> Added conditions to Tailscale installation and start tasks.<br> <li> Simplified logic for setting <code>tailscale_auth_key</code>.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/13/files#diff-4e91b59e98037adc8ba24f697e5b0057aaf84746f7bc1cd3972965b8c3a394c0">+2/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>