### PR TITLE
fix: remove logs for tasks that handle the tailscale auth key

### DIFF
--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -12,6 +12,7 @@
       set_fact:
         tailscale_auth_key: "{{ lookup('env', 'TAILSCALE_AUTH_KEY') }}"
       when: lookup('env', 'TAILSCALE_AUTH_KEY') | length > 0
+      no_log: true
 
     - name: Set timezone to UTC
       timezone:
@@ -77,6 +78,7 @@
     - name: Start tailscale
       command: tailscale up --authkey {{ tailscale_auth_key }} --ssh
       when: tailscale_auth_key is defined
+      no_log: true
     
     - name: Remove systemd-resolved
       apt:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added `no_log: true` to sensitive tasks handling `tailscale_auth_key`.

- Prevented logging of sensitive environment variable values.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server-install.yml</strong><dd><code>Prevent logging of sensitive data in playbook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/server-install.yml

<li>Added <code>no_log: true</code> to the task setting <code>tailscale_auth_key</code>.<br> <li> Added <code>no_log: true</code> to the task starting Tailscale.<br> <li> Ensured sensitive data is not logged during playbook execution.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/14/files#diff-4e91b59e98037adc8ba24f697e5b0057aaf84746f7bc1cd3972965b8c3a394c0">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>