### PR TITLE
fix: change sshd to restart after modifying the sshd config

### DIFF
--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -113,7 +113,6 @@
         owner: root
         group: root
         mode: 0644
-      notify: Restart sshd service
 
     - name: Restart sshd service
       service:

--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -115,6 +115,11 @@
         mode: 0644
       notify: Restart sshd service
 
+    - name: Restart sshd service
+      service:
+        name: sshd
+        state: restarted
+
     - name: Remove all users except root
       user:
         name: "{{ item }}"
@@ -131,9 +136,3 @@
         key: "{{ keys }}"
         state: present
         exclusive: true
-
-  handlers:
-    - name: Restart sshd service
-      service:
-        name: sshd
-        state: restarted


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Moved the `Restart sshd service` task into the main task list.

- Removed the `Restart sshd service` handler from the handlers section.

- Ensured `sshd` service restarts immediately after modifying its configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server-install.yml</strong><dd><code>Refactored sshd restart logic in playbook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/server-install.yml

<li>Added <code>Restart sshd service</code> task directly after modifying <code>sshd_config</code>.<br> <li> Removed the <code>Restart sshd service</code> handler from the handlers section.<br> <li> Ensured immediate restart of <code>sshd</code> service after configuration changes.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/17/files#diff-4e91b59e98037adc8ba24f697e5b0057aaf84746f7bc1cd3972965b8c3a394c0">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>