### PR TITLE
update comments and other refactoring

### DIFF
--- a/playbooks/server-install.yml
+++ b/playbooks/server-install.yml
@@ -192,8 +192,8 @@
 
     - name: Create systemd service file for Nginx Docker Compose
       template:
-        src: ../templates/nginx-docker.service.j2
-        dest: /etc/systemd/system/nginx-docker.service
+        src: ../templates/provisioner-cache.service.j2
+        dest: /etc/systemd/system/provisioner-cache.service
         owner: root
         group: root
         mode: 0644
@@ -203,6 +203,6 @@
 
     - name: Enable and start Nginx Docker Compose service
       service:
-        name: nginx-docker
+        name: provisioner-cache
         enabled: yes
         state: started

--- a/templates/cache.conf.j2
+++ b/templates/cache.conf.j2
@@ -4,18 +4,10 @@ events {
 }
 
 http {
-    # Set up the cache directory and parameters
     proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=my_cache:10m inactive=48h use_temp_path=off;
 
-    # # Buffer settings for large file transfers
-    # client_max_body_size 12g;  # Allow for even larger file uploads (12GB here for safety margin)
-    # client_body_buffer_size 256k;  # Increased buffer for client request body
-    # proxy_buffer_size 128k;  # Buffer size for proxy connection header
-    # proxy_buffers 32 128k;  # Number of buffers and their size for proxy response
-    # proxy_busy_buffers_size 512k;  # Maximum buffer size for busy connections
-    
     server {
-        listen 80;
+        listen 1337;
 
         location / {
             # Proxy pass to the remote server

--- a/templates/docker-compose.yaml.j2
+++ b/templates/docker-compose.yaml.j2
@@ -1,16 +1,8 @@
 version: '3.8'
 services:
-    # web:
-    #   image: nginx:latest
-    #   ports:
-    #     - "8080:80"
-    #   volumes:
-    #     - /opt/nginx/html:/usr/share/nginx/html:ro
-    #     - /opt/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
   cache:
-    image: nginx:latest
+    image: nginx:1.27.5@sha256:c15da6c91de8d2f436196f3a768483ad32c258ed4e1beb3d367a27ed67253e66
     ports:
-      - "127.0.0.1:80:80"
+      - "127.0.0.1:1337:1337"
     volumes:
-      # - /opt/nginx/cache-test:/var/cache/nginx
       - /opt/nginx/cache.conf:/etc/nginx/nginx.conf:ro

--- a/templates/provisioner-cache.service.j2
+++ b/templates/provisioner-cache.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Nginx Docker Compose Service
+Description=Provisioner Cache
 After=docker.service
 Requires=docker.service
 


### PR DESCRIPTION
### **User description**
chore: update comments
major: change port number from 80 to 1337 to keep port 80/443 available for something public facing later
major: renaming nginx-docker systemd unit to provisioner-cache


___

### **PR Type**
enhancement


___

### **Description**
- Change Nginx cache service port from 80 to 1337

- Rename systemd unit from nginx-docker to provisioner-cache

- Update Docker image and port mapping in Docker Compose

- Remove outdated comments and clean up configuration files


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server-install.yml</strong><dd><code>Rename and update systemd unit for cache service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/server-install.yml

<li>Update systemd service template and destination to provisioner-cache<br> <li> Change service name from nginx-docker to provisioner-cache


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/20/files#diff-4e91b59e98037adc8ba24f697e5b0057aaf84746f7bc1cd3972965b8c3a394c0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cache.conf.j2</strong><dd><code>Update Nginx config port and remove old comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/cache.conf.j2

<li>Change Nginx listen port from 80 to 1337<br> <li> Remove commented-out buffer settings and explanatory comments


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/20/files#diff-0b665834886c6ceeb0800486abe7453588fbafc067d0457e47440d0128b9e04b">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yaml.j2</strong><dd><code>Update Docker Compose for new port and image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/docker-compose.yaml.j2

<li>Update Nginx image to a specific version with SHA256 digest<br> <li> Change exposed port from 80 to 1337<br> <li> Remove commented-out legacy configuration


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/20/files#diff-ac00c577ce5a91a377139944e691a89941b95288ef70cb4723602db7de276d4d">+2/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>provisioner-cache.service.j2</strong><dd><code>Update systemd service description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/provisioner-cache.service.j2

- Change service description to Provisioner Cache


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/20/files#diff-0c7368f810cc3fd8d4bb057df110ba6fea69dbb902b53710054f17388f262811">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>