### PR TITLE
fix: remove invalid --no-cache flag from docker compose up command

### DIFF
--- a/templates/provisioner-cache.service.j2
+++ b/templates/provisioner-cache.service.j2
@@ -5,7 +5,7 @@ Requires=docker.service
 
 [Service]
 WorkingDirectory=/opt/provisioner-cache
-ExecStart=/usr/bin/docker compose -f /opt/provisioner-cache/docker-compose.yaml up --remove-orphans --build --no-cache --pull missing --force-recreate
+ExecStart=/usr/bin/docker compose -f /opt/provisioner-cache/docker-compose.yaml up --remove-orphans --build --pull missing --force-recreate
 ExecStop=/usr/bin/docker compose -f /opt/provisioner-cache/docker-compose.yaml down
 Restart=always
 RestartSec=5s


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed invalid `--no-cache` flag from Docker Compose command

- Ensured compatibility with current Docker Compose syntax


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>provisioner-cache.service.j2</strong><dd><code>Remove unsupported --no-cache flag from service file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/provisioner-cache.service.j2

<li>Deleted the unsupported <code>--no-cache</code> flag from the <code>ExecStart</code> command<br> <li> Updated Docker Compose service definition for correct operation


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/22/files#diff-0c7368f810cc3fd8d4bb057df110ba6fea69dbb902b53710054f17388f262811">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>