### PR TITLE
fix: pin ansible-core

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.13.7/.schema/devbox.schema.json",
   "packages": [
-    "ansible@2.19.2",
+    "python313Packages.ansible-core@2.18.6",
     "sshpass@1.10"
   ],
   "shell": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,73 +1,73 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "ansible@2.19.2": {
-      "last_modified": "2025-09-18T16:33:27Z",
-      "resolved": "github:NixOS/nixpkgs/f4b140d5b253f5e2a1ff4e5506edbf8267724bde#ansible",
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2025-09-03T14:58:13Z",
+      "resolved": "github:NixOS/nixpkgs/c6a788f552b7b7af703b1a29802a7233c0067908?lastModified=1756911493&narHash=sha256-6n%2Fn1GZQ%2Fvi%2BLhFXMSyoseKdNfc2QQaSBXJdgamrbkE%3D"
+    },
+    "python313Packages.ansible-core@2.18.6": {
+      "last_modified": "2025-07-17T10:11:59Z",
+      "resolved": "github:NixOS/nixpkgs/fa0ef8a6bb1651aa26c939aeb51b5f499e86b0ec#python313Packages.ansible-core",
       "source": "devbox-search",
-      "version": "2.19.2",
+      "version": "2.18.6",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/jh0rfqxm2zvq5b9db83ymx3zsvlfyd8r-python3.13-ansible-core-2.19.2",
+              "path": "/nix/store/sm9ibx39h8ayzv8hsr95nblcl15qq796-python3.13-ansible-core-2.18.6",
               "default": true
             },
             {
               "name": "dist",
-              "path": "/nix/store/nfcab64b903014bbam1q2h5bq63bm92p-python3.13-ansible-core-2.19.2-dist"
+              "path": "/nix/store/7pk0zzlbgnlyb4srj5swd0hwz5rn3ib4-python3.13-ansible-core-2.18.6-dist"
             }
           ],
-          "store_path": "/nix/store/jh0rfqxm2zvq5b9db83ymx3zsvlfyd8r-python3.13-ansible-core-2.19.2"
+          "store_path": "/nix/store/sm9ibx39h8ayzv8hsr95nblcl15qq796-python3.13-ansible-core-2.18.6"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/qwxyv79z61miblnsnymb4i3kaw2cb5qs-python3.13-ansible-core-2.19.2",
+              "path": "/nix/store/9vrwp2amwf4762bffdfhvz98fl0ms2d0-python3.13-ansible-core-2.18.6",
               "default": true
             },
             {
               "name": "dist",
-              "path": "/nix/store/z3d6zm7bpapdmizxljqlpd67l1cmpmg4-python3.13-ansible-core-2.19.2-dist"
+              "path": "/nix/store/r845dk8zp9fr1q81ds95m56sdz857kmz-python3.13-ansible-core-2.18.6-dist"
             }
           ],
-          "store_path": "/nix/store/qwxyv79z61miblnsnymb4i3kaw2cb5qs-python3.13-ansible-core-2.19.2"
+          "store_path": "/nix/store/9vrwp2amwf4762bffdfhvz98fl0ms2d0-python3.13-ansible-core-2.18.6"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/bpd149p32vlpb8nx93m04i38n61m60l9-python3.13-ansible-core-2.19.2",
+              "path": "/nix/store/xwbi8933gby9hf681ldq6hzd9zr9xvyv-python3.13-ansible-core-2.18.6",
               "default": true
             },
             {
               "name": "dist",
-              "path": "/nix/store/li6gkzsaggwcpnbhdjxajr3ns9gxsrbf-python3.13-ansible-core-2.19.2-dist"
+              "path": "/nix/store/awgibd5nrs3vdxc4agfskcnvnmdlnd8m-python3.13-ansible-core-2.18.6-dist"
             }
           ],
-          "store_path": "/nix/store/bpd149p32vlpb8nx93m04i38n61m60l9-python3.13-ansible-core-2.19.2"
+          "store_path": "/nix/store/xwbi8933gby9hf681ldq6hzd9zr9xvyv-python3.13-ansible-core-2.18.6"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/3xy4gzb1hahqvr1vn045jgrkmxpsx7dz-python3.13-ansible-core-2.19.2",
+              "path": "/nix/store/ljbs2q1ibrk63wk7jp55qnanz5rms0in-python3.13-ansible-core-2.18.6",
               "default": true
             },
             {
               "name": "dist",
-              "path": "/nix/store/kd9w824kcdryc56rcrslbs4drjxk75dk-python3.13-ansible-core-2.19.2-dist"
+              "path": "/nix/store/7xdzjaifq6blck60xbnb59w840yqclyk-python3.13-ansible-core-2.18.6-dist"
             }
           ],
-          "store_path": "/nix/store/3xy4gzb1hahqvr1vn045jgrkmxpsx7dz-python3.13-ansible-core-2.19.2"
+          "store_path": "/nix/store/ljbs2q1ibrk63wk7jp55qnanz5rms0in-python3.13-ansible-core-2.18.6"
         }
       }
-    },
-    "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "last_modified": "2025-09-24T08:19:39Z",
-      "resolved": "github:NixOS/nixpkgs/e2642aa7d5a15eae586932a56f4294934f959c14?lastModified=1758701979&narHash=sha256-c7DUti3XM1aga8oVgaPnrVmEeCFtN9PaBxyNuqx8jPc%3D"
     },
     "sshpass@1.10": {
       "last_modified": "2025-09-18T16:33:27Z",


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Pin `ansible-core` to specific version 2.18.6

- Replace generic `ansible` package with Python-specific variant


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ansible@2.19.2"] -- "replaced with" --> B["python313Packages.ansible-core@2.18.6"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devbox.json</strong><dd><code>Pin ansible-core package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

devbox.json

<ul><li>Replace <code>ansible@2.19.2</code> with <code>python313Packages.ansible-core@2.18.6</code><br> <li> Pin ansible-core to specific version for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner-node-setup/pull/62/files#diff-3d4c81b2bef90b8980e7c7c4900d75007f13acf07d9e62aa509f2d53f9fa4ef9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

